### PR TITLE
Enable syncing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,7 @@ RUN poetry install
 EXPOSE 3000
 
 ENTRYPOINT ["api-start"]
+
+FROM prod AS sync
+
+ENTRYPOINT ["api-sync"]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,20 @@
-# Velodrome Finance HTTP API 🚲💨🕸️
+# Equilibre Finance HTTP API 🚲💨🕸️
 
-Velodrome Finance HTTP API is used by our app to fetch tokens and liquidity
+Equilibre Finance HTTP API is used by our app to fetch tokens and liquidity
 pool pairs.
 
 Please make sure you have [Docker](https://docs.docker.com/install/) first.
 
-To build the image, run:
-```
-$ docker build ./ -t velodrome/api
-```
-
 Next, make a copy of the `env.example` file, and update the relevant variables.
 
-Finally, to start the container, run:
-```
-$ docker run --rm --env-file=env.example.copy -v $(pwd):/app -p 3001:3001 -w /app -it velodrome/api
-```
+Finally, to start the services run:
 
-To run the syncer (refreshes data from chain) process, run:
-```
-$ docker run --rm --env-file=env.example.copy -v $(pwd):/app -p 3001:3001 -w /app -it velodrome/api sh -c 'python -m app.pairs.syncer'
-```
+    docker compose up
+
+This will start three services:
+- `api`: the backend
+- `sync`: the service that is constantly syncing information on pairs from the chain
+- A redis instance
 
 ## Running locally
 This project is set up with [`poetry`](https://python-poetry.org/docs/) and Python 3.9.14. We recommend installing
@@ -30,9 +24,13 @@ Installing dependencies:
 
     poetry install
 
-Running the project (after the previous command)
+Running the API (after the previous command)
 
     api-start
+
+Running the syncing process (needed for scraping data from the chain)
+
+    api-sync
 
 This will spawn and use a virtual environment in `.venv` and install the dependencies defined in `poetry.lock`
 (or `pyproject.toml`) if the lock file was missing (which should not happen).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This will start three services:
 This project is set up with [`poetry`](https://python-poetry.org/docs/) and Python 3.9.14. We recommend installing
 [`pyenv`](https://github.com/pyenv/pyenv) to easily manage different Python versions.
 
+**Note**: Make sure you update your `.env` file to point to localhost (i.e: redis url)
+
 Installing dependencies:
 
     poetry install

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.9"
 
 services:
   redis:
@@ -11,13 +11,26 @@ services:
   api:
     build:
       context: .
+      target: prod
     ports:
       - "8000:8000"
     volumes:
       - ./:/app
     networks:
       - backend
+    env_file:
+      - .env
 
+  sync:
+    build:
+      context: .
+      target: sync
+    volumes:
+      - ./:/app
+    networks:
+      - backend
+    env_file:
+      - .env
 
 networks:
   backend:

--- a/env.example
+++ b/env.example
@@ -2,7 +2,7 @@
 PORT=8000
 
 # Databases config
-REDIS_URL=redis://localhost:6379/0
+REDIS_URL=redis://redis:6379/0
 
 # Web3
 WEB3_PROVIDER_URI=https://evm.kava.io

--- a/poetry.lock
+++ b/poetry.lock
@@ -467,7 +467,7 @@ varint = "*"
 
 [[package]]
 name = "multicall"
-version = "0.5.1"
+version = "0.6.0"
 description = "aggregate results from multiple ethereum contract calls"
 category = "main"
 optional = false
@@ -475,14 +475,14 @@ python-versions = "^3.8"
 develop = false
 
 [package.dependencies]
-eth_retry = "^0.1.0"
-web3 = "5.27.0"
+eth_retry = "^0.1.8"
+web3 = "^5.27"
 
 [package.source]
 type = "git"
-url = "https://github.com/velodrome-finance/multicall.py"
-reference = "v0.5.1"
-resolved_reference = "032be67cab3309557d0d910133b551404e27ded7"
+url = "https://github.com/equilibre-finance/multicall.py"
+reference = "v0.1.0"
+resolved_reference = "e7a14beb61570b5c5de57b20a327c50ea2e8b862"
 
 [[package]]
 name = "multidict"
@@ -827,7 +827,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "c8ec6310fc65db6088f1f61a16d559c127d1eaabd173a2a30c0b1db11bdfabdd"
+content-hash = "20ba39fd4dea682333c2314a0d7867dda3bb1c9828ee9fd4b0b234cbc46c8979"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ black = "^22.8.0"
 
 [tool.poetry.scripts]
 api-start = 'app.app:main'
+api-sync = 'app.pairs.syncer:sync_forever'
+api-sync-once = 'app.pairs.syncer:sync'
 
 [build-system]
 requires = ["poetry>=1.2.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ falcon = "3.1"
 falcon-compression = "0.2.1"
 bjoern = "3.2.1"
 web3 = "5.27.0"
-multicall = { git = "https://github.com/velodrome-finance/multicall.py", tag = "v0.5.1" }
+multicall = { git = "https://github.com/equilibre-finance/multicall.py", tag = "v0.1.0" }
 redis = "4.2.2"
 fakeredis = "1.7.4"
 walrus = "0.9.1"


### PR DESCRIPTION
This PR makes it easier to start up a fully functional backend by providing the following:
- Another command (`api-sync`) that runs `app.pairs.syncer.sync_forever` to fetch data from the chain and load it in Redis
- Extends the `docker-compose.yml` so that it runs by default all services needed to work (api, sync and redis)
- Updates documentation

Also, in previous commits produced straight against `main` I updated our dependencies so that the package `multicall.py` actually contains Kava related data.